### PR TITLE
feat: add access control

### DIFF
--- a/contracts/InterchainProposalExecutor.sol
+++ b/contracts/InterchainProposalExecutor.sol
@@ -36,8 +36,8 @@ contract InterchainProposalExecutor is AxelarExecutable, Ownable {
      * - `data` is the encoded function arguments.
      */
     function _execute(
-        string calldata sourceAddress,
         string calldata,
+        string calldata sourceAddress,
         bytes calldata payload
     ) internal override {
         // Check that the source address is the same as the source interchain sender
@@ -47,36 +47,28 @@ contract InterchainProposalExecutor is AxelarExecutable, Ownable {
         );
 
         // Decode the payload
-        (
-            address interchainProposalCaller,
-            address[] memory targets,
-            uint256[] memory values,
-            string[] memory signatures,
-            bytes[] memory data
-        ) = abi.decode(
-                payload,
-                (address, address[], uint256[], string[], bytes[])
-            );
+        (address interchainProposalCaller, bytes memory _payload) = abi.decode(
+            payload,
+            (address, bytes)
+        );
 
         // Execute the proposal
-        _executeProposal(
-            interchainProposalCaller,
-            targets,
-            values,
-            signatures,
-            data
-        );
+        _executeProposal(interchainProposalCaller, _payload);
 
         emit ProposalExecuted(keccak256(payload));
     }
 
     function _executeProposal(
         address proposalCaller,
-        address[] memory targets,
-        uint256[] memory values,
-        string[] memory signatures,
-        bytes[] memory data
+        bytes memory payload
     ) internal onlyWhitelistedCaller(proposalCaller) {
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            string[] memory signatures,
+            bytes[] memory data
+        ) = abi.decode(payload, (address[], uint256[], string[], bytes[]));
+
         // Iterate over all targets and call them with the given data
         for (uint256 i = 0; i < targets.length; i++) {
             // Construct the call data

--- a/contracts/InterchainProposalSender.sol
+++ b/contracts/InterchainProposalSender.sol
@@ -33,14 +33,6 @@ contract InterchainProposalSender is Ownable {
             bytes[] memory data
         ) = abi.decode(payload, (address[], uint256[], string[], bytes[]));
 
-        bytes memory _payload = abi.encode(
-            msg.sender,
-            targets,
-            values,
-            signatures,
-            data
-        );
-
         require(targets.length > 0, "InterchainProposalSender: no targets");
         require(
             targets.length == values.length &&
@@ -49,15 +41,17 @@ contract InterchainProposalSender is Ownable {
             "InterchainProposalSender: invalid payload"
         );
 
+        bytes memory encodedSenderPayload = abi.encode(msg.sender, payload);
+
         if (msg.value > 0) {
             gasService.payNativeGasForContractCall{value: msg.value}(
                 address(this),
                 destinationChain,
                 destinationContract,
-                _payload,
+                encodedSenderPayload,
                 msg.sender
             );
         }
-        gateway.callContract(destinationChain, destinationContract, _payload);
+        gateway.callContract(destinationChain, destinationContract, encodedSenderPayload);
     }
 }

--- a/test/utils/deploy.ts
+++ b/test/utils/deploy.ts
@@ -22,10 +22,11 @@ export function deployInterchainProposalSender(deployer: Wallet) {
   ]);
 }
 
-export function deployInterchainProposalExecutor(deployer: Wallet) {
+export function deployInterchainProposalExecutor(deployer: Wallet, interchainSenderAddress: string) {
   const chains = getChains();
   return deploy(deployer, chains[1].rpc, "InterchainProposalExecutor", [
     chains[1].gateway,
+    interchainSenderAddress
   ]);
 }
 

--- a/test/utils/wait.ts
+++ b/test/utils/wait.ts
@@ -1,13 +1,18 @@
 import { Contract, ethers } from "ethers";
 
 export const waitProposalExecuted = (
+  timelockAddress: string,
   payload: string,
   executorContract: Contract
 ) =>
   new Promise((resolve, reject) => {
+    const encodedSenderPayload = ethers.utils.defaultAbiCoder.encode(
+      ["address", "bytes"],
+      [timelockAddress, payload]
+    );
     executorContract.on(
       executorContract.filters.ProposalExecuted(
-        ethers.utils.keccak256(payload)
+        ethers.utils.keccak256(encodedSenderPayload)
       ),
       (payloadHash) => {
         resolve(payloadHash);


### PR DESCRIPTION
# Description

This PR introduces access control for the executor contract, ensuring trust and security when executing functions on other contracts. The following restrictions have been implemented:

- Only the allowed `InterchainProposalSender` contract can send interchain proposal messages to this contract.
- The caller invoking the `InterchainProposalSender` contract must be whitelisted, and their address will be encoded in the payload before sending it to the gateway contract.

These updates enhance access control and reinforce trust between contracts.